### PR TITLE
PT-304 fix date validation bug for when running locale FR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Blip 
 
+## [Unreleased]
+
+### Fixed
+
+- PT-304 Validation of the patient diagnostic date and date of birth uses the wrong format
+
 ## [0.4.0] - 2019-05-15
 
 ### ADDED

--- a/app/core/validation.js
+++ b/app/core/validation.js
@@ -65,7 +65,9 @@ export const invalid = (message) => ({
  */
 const dateValidator = (fieldLabel, fieldValue, currentDateObj) => {
   let now = new Date();
-  let dateMask = t('M-D-YYYY');
+  // dateMask will be used for date validation
+  // it is static and does not depend on any locale here
+  let dateMask = 'M-D-YYYY';
   let dateString;
 
   currentDateObj = currentDateObj || Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
@@ -78,8 +80,8 @@ const dateValidator = (fieldLabel, fieldValue, currentDateObj) => {
     return invalid(errors.incompleteDate(fieldLabel));
   }
 
+  // Build date as a string, dateMask-formatted for comparison
   let month = parseInt(fieldValue.month, 10) + 1; // month is zero indexed
-
   dateString = `${month}-${fieldValue.day}-${fieldValue.year}`;
   if (!sundial.isValidDateForMask(dateString, dateMask)) {
     return invalid(errors.invalidDate());

--- a/test/unit/pages/patientnew.test.js
+++ b/test/unit/pages/patientnew.test.js
@@ -1,4 +1,6 @@
 /* global beforeEach */
+/* global before */
+/* global after */
 /* global chai */
 /* global describe */
 /* global sinon */
@@ -115,7 +117,7 @@ describe('PatientNew', function () {
         When a patient want to create his/her profile on Blip
         If the local is 'fr' then the date format was incorrectly parsed
     */
-    describe("When local=fr", () => {
+    describe('When local=fr', () => {
       before((done)=> {
         i18n.off('languageChanged');
         i18n.changeLanguage('fr', (err, t) => {

--- a/test/unit/utils/validation.test.js
+++ b/test/unit/utils/validation.test.js
@@ -1,6 +1,9 @@
 /* global chai */
 /* global describe */
 /* global it */
+/* global before */
+/* global after */
+
 import * as validation from '../../../app/core/validation';
 import i18n from 'i18next';
 
@@ -269,7 +272,6 @@ describe('validation', () => {
 
     describe('Specific date format: FR', () => {
       before((done) => {
-        self.localStorage.lang = "fr";
         i18n.off('languageChanged');
         i18n.changeLanguage('fr', (err, t) => {
             if(err) console.log(err);


### PR DESCRIPTION
Problem was due to the fact that the date mask was localized which it should not as the date it compares to is static M-D-YYYY