### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2019-08-09
+
 ### Added
 - PT-545 Display infusion site changes for Diabeloop Devices
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.20.2-dblp.0.5.0",
+  "version": "1.20.2-dblp.0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip",
-  "version": "1.20.2-dblp.0.5.0",
+  "version": "1.20.2-dblp.0.6.0",
   "private": true,
   "scripts": {
     "test": "TZ=UTC NODE_ENV=test ./node_modules/karma/bin/karma --log-level debug start",


### PR DESCRIPTION
## [0.6.0] - 2019-08-09

### Added
- PT-545 Display infusion site changes for Diabeloop Devices

### Fixed
- PT-532 One can create a patient even if the application is not allowing it