### PR TITLE
Add matomo site id and refactor a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ It is based on Tidepool Blip 1.27.
 
 ### Fixed
  - PT-808 fix minor bugs identified after the release of blip 0.9.0
+ - PT-814 distinguish matomo data origin (preview vs clinical vs commercial)
 
 ## [0.9.0] 2019-11-08
 ### Changed

--- a/index.ejs
+++ b/index.ejs
@@ -12,25 +12,14 @@
   <div id="app">
     <p class="loading">Loading app...</p>
   </div>
+  
+  <!-- Zendesk -->
   <!-- config -->
   <!-- Start of support Zendesk Widget script -->
   <script id="ze-snippet" type="text/javascript" src="https://static.zdassets.com/ekr/snippet.js?key=d1aad8b3-67d8-4f44-9d87-9e8a0ed8149d"></script>
   <!-- End of support Zendesk Widget script -->
   <!-- Start of Tracker Code -->
-  <script id="tracker-script" type="text/javascript">
-    var _paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['requireConsent']);
-    _paq.push(['trackPageView']);
-    (function () {
-      const u = '//localhost:8091/';
-      _paq.push(['setTrackerUrl', u + 'matomo.php']);
-      _paq.push(['setSiteId', '1']);
-      const d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-      g.type = 'text/javascript'; g.async = true; g.defer = true; g.src = u + 'matomo.js';
-      s.parentNode.insertBefore(g, s);
-    })();
-  </script>
+  <script type="text/javascript" src="matomo.js"></script>
   <!-- End of Tracker Code -->
 </body>
 

--- a/index.ejs
+++ b/index.ejs
@@ -12,8 +12,6 @@
   <div id="app">
     <p class="loading">Loading app...</p>
   </div>
-  
-  <!-- Zendesk -->
   <!-- config -->
   <!-- Start of support Zendesk Widget script -->
   <script id="ze-snippet" type="text/javascript" src="https://static.zdassets.com/ekr/snippet.js?key=d1aad8b3-67d8-4f44-9d87-9e8a0ed8149d"></script>

--- a/matomo.js
+++ b/matomo.js
@@ -1,0 +1,14 @@
+var _paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(["setDoNotTrack", true]);
+_paq.push(['requireConsent']);
+_paq.push(['trackPageView']);
+(function () {
+    const u = '//localhost:8091/';
+    const id = 1;
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', id]);
+    const d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.type = 'text/javascript'; g.async = true; g.defer = true; g.src = u + 'matomo.js';
+    s.parentNode.insertBefore(g, s);
+})();


### PR DESCRIPTION
Setting the site id is required to redirect to the correct website (clinical, commercial, preview...). As of now everything is linked to the preview url...
Site ids can be found on matomo website. FYI this is: 1 for preview, 2 for clincial and 3 for commercial

Refactor: Let's split matomo script from the index file and just include a dedicated script (as for zendesk or config)
