### PR TITLE
Have clinician selected by default for signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ It is based on Tidepool Blip 1.27.
 ### Fixed
 - PT-338 Fix some translations.
 
+### Changed
+- PT-1052 Rework page for clinician sign up
+
 ### Added
 - PT-875 Flexible period in Trending page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ It is based on Tidepool Blip 1.27.
 - PT-338 Fix some translations.
 
 ### Changed
-- PT-1052 Rework page for clinician sign up
+- PT-1052 Rework sign up (direct link to clinician signup from home page + clinician option selected as default in signup page)
 
 ### Added
 - PT-875 Flexible period in Trending page

--- a/app/components/loginnav/loginnav.js
+++ b/app/components/loginnav/loginnav.js
@@ -49,7 +49,7 @@ var LoginNav = translate()(React.createClass({
 
     var self = this;
     const {page, t} = this.props;
-    var href = '/signup';
+    var href = '/signup/clinician';
     var className = 'js-signup-link';
     var icon = 'icon-add';
     var text = t('Sign up');

--- a/app/pages/signup/signup.js
+++ b/app/pages/signup/signup.js
@@ -113,7 +113,7 @@ export let Signup = translate()(React.createClass({
       formValues: formValues,
       validationErrors: {},
       notification: null,
-      selected: null,
+      selected: 'clinician',
       madeSelection: false
     }, this.getFormStateFromPath(this.props.location.pathname));
   },


### PR DESCRIPTION
Almost smallest PR of the year :)
There are 2 things here:
- direct link from the home to signup/clinician
- "clinician" option selected by default in /signup (as this page is still reached from emails)