### PR TITLE
PT-1309 Add SOUP list build and publish to the pipeline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://nexus.ci.diabeloop.eu/repository/npm-diabeloop/
+email=jenkins@diabeloop.fr
+_auth=${nexus_token}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ node_js:
 
 cache: npm
 
+env:
+  jobs:
+    - BUILD_SOUP=true
+
 before_install:
   - if [[ `npm -v` != 6* ]]; then npm install -g npm@6; fi
 
@@ -17,28 +21,42 @@ install:
   - npm install
 
 deploy:
-  # Control deployment by setting a value for `on`. Setting the `branch`
-  # option to `master` means Travis will only attempt a deployment on
-  # builds of your repo's master branch (e.g., after you merge a PR).
-  on:
-    tags: true
-    node_js: 10.15.3
-#    branch: dbl
-  provider: s3
-  # You can refer to environment variables from Travis repo settings!
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  region: $AWS_DEFAULT_REGION
-  # Name of the S3 bucket to which your site should be uploaded.
-  bucket: $AWS_BUCKET
-  # Prevent Travis from deleting your built site so it can be uploaded.
-  skip_cleanup: true
-  # Path of the source directory containing your built site.
-  local_dir: deploy
-  # Path to a directory containing your built site.
-  upload-dir: deploy
-  # Set the Cache-Control header.
-  cache_control: "max-age=21600"
+  - provider: s3
+    on:
+      tags: true
+      node_js: 10.15.3
+    # You can refer to environment variables from Travis repo settings!
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: $AWS_DEFAULT_REGION
+    # Name of the S3 bucket to which your site should be uploaded.
+    bucket: $AWS_BUCKET
+    # Prevent Travis from deleting your built site so it can be uploaded.
+    skip_cleanup: true
+    # Path of the source directory containing your built site.
+    local_dir: deploy
+    # Path to a directory containing your built site.
+    upload-dir: deploy
+    # Set the Cache-Control header.
+    cache_control: "max-age=21600"
+  # Deploy SOUP list
+  - provider: s3
+    on:
+      tags: true
+    # You can refer to environment variables from Travis repo settings!
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: $AWS_DEFAULT_REGION
+    # Name of the S3 bucket to which your site should be uploaded.
+    bucket: com.diabeloop.yourloops.doc
+    # Prevent Travis from deleting your built site so it can be uploaded.
+    skip_cleanup: true
+    # Path of the source directory containing your built site.
+    local_dir: doc
+    # Path to a directory containing your built site.
+    upload-dir: soup/blip
+    # Set the Cache-Control header.
+    cache_control: "max-age=21600"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,19 +42,15 @@ deploy:
     cache_control: "max-age=21600"
   # Deploy SOUP list
   - provider: s3
-    # You can refer to environment variables from Travis repo settings!
+      on:
+        branch: feature/PT-1309_viz_tideline_deps
     access_key_id: $AWS_ACCESS_KEY_ID
     secret_access_key: $AWS_SECRET_ACCESS_KEY
     region: $AWS_DEFAULT_REGION
-    # Name of the S3 bucket to which your site should be uploaded.
     bucket: com.diabeloop.yourloops.doc
-    # Prevent Travis from deleting your built site so it can be uploaded.
     skip_cleanup: true
-    # Path of the source directory containing your built site.
     local_dir: doc
-    # Path to a directory containing your built site.
     upload-dir: soup/blip
-    # Set the Cache-Control header.
     cache_control: "max-age=21600"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ deploy:
     cache_control: "max-age=21600"
   # Deploy SOUP list
   - provider: s3
-    on:
-      tags: true
     # You can refer to environment variables from Travis repo settings!
     access_key_id: $AWS_ACCESS_KEY_ID
     secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 
 install:
   - npm install
+  - npm install --save-dev ci-toolbox@2.1.1
 
 deploy:
   - provider: s3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ It is based on Tidepool Blip 1.27.
 
 ## Unreleased
 ### Changed
+- PT-1309 Ensure Blip SOUP list includes viz and tideline SOUPs
+
+### Changed
 - PT-1256 Improve PDF generation
 ### Engineering use
 - PT-1249 Reduce blip & viz build time.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ### Stage 0 - Base image
 FROM node:10.15.3-alpine as base
+
 WORKDIR /app
+
 RUN \
   mkdir -p dist node_modules \
   && chown -R node:node . \
@@ -29,8 +31,12 @@ ENV \
 ### Stage 2 - Create cached `node_modules`
 # Only rebuild layer if `package.json` has changed
 FROM base as dependencies
-COPY package.json .
-ENV nexus_token=''
+
+ARG npm_token
+ENV nexus_token=$npm_token
+
+COPY package.json .npmrc ./
+
 # Run as node user, so that npm run the prepare scripts in dependencies
 USER node
 RUN \

--- a/artifact.sh
+++ b/artifact.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-wget -q -O artifact_node.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/artifact_node.sh'
+wget -q -O artifact_node.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_soup_generation/artifact/artifact_node.sh'
 wget -q -O artifact_images.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/artifact_images.sh'
 
 declare -a languages

--- a/package.json
+++ b/package.json
@@ -26,17 +26,20 @@
     "install-selenium": "./node_modules/selenium-standalone/bin/selenium-standalone install --version=2.53.0",
     "build-docs": "./update-gh-pages.sh",
     "serve-docs": "./node_modules/.bin/gitbook serve",
-    "update-translations": "i18next 'app/**/*.js' 'node_modules/tideline/{plugins,js}/**/*.js' 'node_modules/@tidepool/viz/src/**/*.js' -c i18next-parser.config.json -o ."
+    "update-translations": "i18next 'app/**/*.js' 'node_modules/tideline/{plugins,js}/**/*.js' 'node_modules/@tidepool/viz/src/**/*.js' -c i18next-parser.config.json -o .",
+    "build-soup": "release-helper gen-dep-report --deep-dep @tidepool/viz,tideline doc/${npm_package_name}-${npm_package_version}-soup.md"
   },
   "engines": {
     "node": ">=10.x",
     "npm": ">=6.x"
   },
   "dependencies": {
+    "@tidepool/viz": "mdblp/viz#dblp.0.12.1",
     "body-parser": "1.18.3",
     "express": "4.16.3",
     "hakken": "mdblp/hakken#dblp.0.2.0",
-    "helmet": "3.13.0"
+    "helmet": "3.13.0",
+    "tideline": "mdblp/tideline#dblp.1.10.0"
   },
   "devDependencies": {
     "@babel/cli": "7.1.0",
@@ -44,7 +47,6 @@
     "@babel/polyfill": "7.0.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
-    "@tidepool/viz": "mdblp/viz#dblp.0.12.1",
     "async": "2.6.1",
     "autoprefixer": "9.1.5",
     "babel-core": "7.0.0-bridge.0",
@@ -136,7 +138,6 @@
     "source-map-loader": "0.2.4",
     "style-loader": "0.23.0",
     "sundial": "mdblp/sundial#dblp.0.1.0",
-    "tideline": "mdblp/tideline#dblp.1.10.0",
     "tidepool-platform-client": "0.41.0",
     "tidepool-standard-action": "0.1.1",
     "terser-webpack-plugin": "3.0.1",


### PR DESCRIPTION
This PR is to add steps to the Travis pipeline for the build and publish of the SOUPs list.

It has dependencies on _ci-toolbox_ (https://github.com/mdblp/ci-toolbox/pull/21) that includes a review of gen-dep-report to optionally retrieve 2nd level dependencies, and on _tools_ (https://github.com/mdblp/tools/pull/17) which ensures node artifacts generate the SOUP list.

Several strategies were possible here and I chose to have the "ci-toolbox" used as a npm package that is saved in the _devDependencies_ of the project. It will not be deployed in the final distributions