### PR TITLE
Apply a new crowdin option to avoid loss of translations

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
 files:
   - source: /locales/en/translation.json
     translation: /locales/%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved


### PR DESCRIPTION
Translations are lost when we update the english (master) translation.
This new option solves the problem