### PR TITLE
YLP-315 display a maintenance page on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ It is based on Tidepool Blip 1.27.
 - YLP-280 Make France as default country for existing users
 ### Engineering Use
 - YLP-211 Rework Cloudfront deployment services to use an alternate domain name
+- YLP-345 Add a "maintenance state" to our CloudFront config
 
 ## 1.6.0 - 2020-11-10
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM node:12.18.3-alpine as deployment
 WORKDIR /cloudfront-dist
 COPY ./cloudfront-dist/deployment/bin ./deployment/bin
 COPY ./cloudfront-dist/deployment/lib ./deployment/lib
+COPY ./cloudfront-dist/assets ./assets
 COPY ./cloudfront-dist/deployment/package.json ./deployment/package.json
 COPY ./cloudfront-dist/deployment/package-lock.json ./deployment/package-lock.json
 COPY ./cloudfront-dist/deployment/.npmignore ./deployment/npmignore

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,9 +18,6 @@ pipeline {
                             returnStdout: true
                         ).trim().toUpperCase()
                     }
-                    if (env.version == "UNRELEASED") {
-                        env.version = "master"
-                    }
                 }
             }
         }
@@ -69,6 +66,11 @@ pipeline {
         stage('Publish') {
             when { branch "dblp" }
             steps {
+                script {
+                    if (env.version == "UNRELEASED") {
+                        env.version = "master"
+                    }
+                }
                 withCredentials([string(credentialsId: 'DEV_AWS_ACCESS_KEY', variable: 'AWS_ACCESS_KEY_ID'),
                     string(credentialsId: 'DEV_AWS_SECRET_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                     string(credentialsId: 'AWS_ACCOUNT_ID', variable: 'AWS_ACCOUNT')]) {

--- a/cloudfront-dist/assets/maintenance/index.html
+++ b/cloudfront-dist/assets/maintenance/index.html
@@ -1,0 +1,31 @@
+<style>
+    body {
+        font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+        font-size: 16px;
+        line-height: 20px;
+        color: #6d6d6d;
+    }
+    .logo {
+        text-align: center
+    }
+    .container {
+        width: 580px;
+        padding-left: 40px;
+        padding-right: 40px;
+        margin-right: auto;
+        margin-left: auto;
+        margin-top: 50vh; 
+        transform: translateY(-50%);
+    }
+    .message {
+        margin-top: 60px;
+    }
+</style>
+<div class="container">
+    <div class="logo">
+        <img src="https://s3-eu-west-1.amazonaws.com/com.diabeloop.public-assets/img/logo.png" alt="Yourloops" height="45"/>
+    </div>
+    <div class="message">
+        The application is under maintenance. Please try to refresh your browser in a few minutes.
+    </div>
+</div>

--- a/cloudfront-dist/assets/maintenance/index.html
+++ b/cloudfront-dist/assets/maintenance/index.html
@@ -1,12 +1,13 @@
 <style>
     body {
-        font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif;
+        font-family: Basis,Helvetica Neue,Helvetica,Arial,sans-serif;
         font-size: 16px;
         line-height: 20px;
         color: #6d6d6d;
     }
     .logo {
-        text-align: center
+        text-align: center;
+        margin-bottom: 60px;
     }
     .container {
         width: 580px;
@@ -18,7 +19,12 @@
         transform: translateY(-50%);
     }
     .message {
-        margin-top: 60px;
+        margin-top: 30px;
+        margin-bottom: 30px;
+    }
+    .link {
+        color: #0d8092;
+        text-decoration: none;
     }
 </style>
 <div class="container">
@@ -26,6 +32,19 @@
         <img src="https://s3-eu-west-1.amazonaws.com/com.diabeloop.public-assets/img/logo.png" alt="Yourloops" height="45"/>
     </div>
     <div class="message">
-        The application is under maintenance. Please try to refresh your browser in a few minutes.
+        YourLoops is down for maintenance. <br>
+        Visit our 
+        <a class="link" href="https://yourloops.statuspage.io">
+            status page
+        </a> to know when the application will be back and running.
+    </div>
+    <hr>
+    <div class="message">
+        YourLoops est en cours de maintenance. <br>
+        Vous pouvez consulter notre 
+        <a class="link" href="https://yourloops.statuspage.io">
+            page de status
+        </a> (en anglais) pour savoir quand l&apos;application sera de nouveau disponible.
     </div>
 </div>
+

--- a/cloudfront-dist/deployment/README.md
+++ b/cloudfront-dist/deployment/README.md
@@ -60,9 +60,14 @@ export AWS_PROFILE=fso-dev
 now that the installation is complete, you could perform a deployment:
 
 ```sh
+source .env #or whatever your env file is called
 cdk synth # to test the deployment
 cdk deploy <STACK_PREFIX_NAME>-blip
 ```
+
+### Set the web site in maintenance mode
+To force the display of a maintenance page you need to set the env var `MAINTENANCE` to `true` and then execute a deployment as described above.  
+To revert from a maintenance state to a "normal" state make sure to reset the env var `MAINTENANCE` to `false` and then (re)execute a deployment.  
 
 *tips:*
 

--- a/cloudfront-dist/deployment/bin/staticwebsite-cdk.ts
+++ b/cloudfront-dist/deployment/bin/staticwebsite-cdk.ts
@@ -12,16 +12,17 @@ const STACK_VERSION = process.env.STACK_VERSION;
 const DOMAIN_NAME = process.env.DOMAIN_NAME;
 const ALT_DOMAIN_NAME = process.env.ALT_DOMAIN_NAME;
 const DNS_ZONE = process.env.DNS_ZONE;
-const BUCKET = process.env.BUCKET;
+const BUCKET = 'com.diabeloop.yourloops-cf';
 
 const FRONT_APP_NAME = process.env.FRONT_APP_NAME;
 const LAMBDA_EDGE_STACK_NAME = `${STACK_PREFIX_NAME}-${FRONT_APP_NAME}-lambda-edge`;
 const APP_STACK_NAME = `${STACK_PREFIX_NAME}-${FRONT_APP_NAME}`;
+const maintenance = (process.env.MAINTENANCE !== undefined && process.env.MAINTENANCE === "true") ? true : false;
 
 const app = new cdk.App();
 
 let distDir = path.resolve(__dirname, '../../../dist');
-if(process.env.DIST_DIR !== undefined && process.env.DIST_DIR !== '') {
+if (process.env.DIST_DIR !== undefined && process.env.DIST_DIR !== '') {
   distDir = path.resolve(process.env.DIST_DIR);
 }
 console.info(`Using app dist directory: '${distDir}'`);
@@ -29,22 +30,26 @@ console.info(`Using app dist directory: '${distDir}'`);
 // Create edge Lambda
 const ls = new LambdaStack(app, LAMBDA_EDGE_STACK_NAME, distDir, {
   env: {
-        region: 'us-east-1' // hardcoded because it should not change with current version of AWS !
-      }
-  },
+    region: 'us-east-1' // hardcoded because it should not change with current version of AWS !
+  }
+},
   STACK_PREFIX_NAME);
 
 // Create ressouce needed to static hosting with cloudfront
 new StaticWebSiteStack(app, APP_STACK_NAME, distDir, {
-    env: {
-      account: AWS_ACCOUNT,
-      region: AWS_DEFAULT_REGION
-    }, 
-    domainName: DOMAIN_NAME,
-    altDomainName: ALT_DOMAIN_NAME,
-    zone: DNS_ZONE,
-    FrontAppName: FRONT_APP_NAME, 
-    prefix: STACK_PREFIX_NAME, 
-    version: STACK_VERSION,
-    rootBucketName: BUCKET
-  }).addDependency(ls);
+  env: {
+    account: AWS_ACCOUNT,
+    region: AWS_DEFAULT_REGION
+  },
+  domainName: DOMAIN_NAME,
+  altDomainName: ALT_DOMAIN_NAME,
+  zone: DNS_ZONE,
+  FrontAppName: FRONT_APP_NAME,
+  prefix: STACK_PREFIX_NAME,
+  version: STACK_VERSION,
+  rootBucketName: BUCKET
+}, maintenance).addDependency(ls);
+
+
+
+


### PR DESCRIPTION
[YLP-315] Add a new variabe `MAINTENANCE` to the CDK deployment script to force the redirection of users to a maintenance page during system maintenance windows.

Not sure it is the best way to address this. It works but there are some potentiel issues:
* the application (blip) will continue to run on client side, using cache, untill the user refresh the page. To be 100% safe there shold be a mechanism in the application itself to force the display of the maintenance page.
* the page is not localized.

[YLP-315]: https://diabeloop.atlassian.net/browse/YLP-315