### PR TITLE
YLP-282 Update CSS for the basal/bolus ratio widget

### DIFF
--- a/packages/viz/src/components/common/stat/Stat.css
+++ b/packages/viz/src/components/common/stat/Stat.css
@@ -253,7 +253,7 @@ svg.statWheelTimeInAuto .offEllipse {
   pointer-events: none;
 }
 .nobar .nobarRowTitle {
-  color: var(--text-medium-contrast);
+  color: var(--stat--default);
 }
 .nobar .nobarRowValue {
   border-width: 2px;

--- a/packages/viz/src/components/common/stat/Stat.css
+++ b/packages/viz/src/components/common/stat/Stat.css
@@ -269,7 +269,7 @@ svg.statWheelTimeInAuto .offEllipse {
 }
 .nobar .nobarRowPercent .nobarPercentValue {
   font-family: "Basis", "Helvetica Neue", Helvetica, Arial, sans-serif !important;
-  font-weight: 400;
+  font-weight: 500;
   font-size: 24px;
 }
 .nobar .nobarRowPercent .nobarPercentUnits {

--- a/packages/viz/src/components/common/stat/Stat.css
+++ b/packages/viz/src/components/common/stat/Stat.css
@@ -250,6 +250,7 @@ svg.statWheelTimeInAuto .offEllipse {
   display: grid;
   row-gap: 4px;
   margin-bottom: 0.5em;
+  pointer-events: none;
 }
 .nobar .nobarRowTitle {
   color: var(--text-medium-contrast);
@@ -261,16 +262,19 @@ svg.statWheelTimeInAuto .offEllipse {
   border-radius: 14px;
   text-align: center;
   font-size: 14px;
+  font-weight: 500;
 }
 .nobar .nobarRowPercent {
   text-align: right;
 }
 .nobar .nobarRowPercent .nobarPercentValue {
+  font-family: "Basis", "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+  font-weight: 400;
   font-size: 24px;
 }
 .nobar .nobarRowPercent .nobarPercentUnits {
 	font-size: 12px;
-	font-weight: 500;
+	font-weight: 400;
   color: var(--text-medium-contrast);
 }
 .nobar-totalInsulin {
@@ -280,5 +284,5 @@ svg.statWheelTimeInAuto .offEllipse {
   color: var(--basal-automated);
 }
 .nobar-totalInsulin-bolus {
-  color: var(--bolus);
+  color: var(--bolus-meal);
 }


### PR DESCRIPTION
Ancien CSS:
![image](https://user-images.githubusercontent.com/53182545/103658086-0b067680-4f6b-11eb-9459-fcd133d4cb7e.png)

Nouveau CSS:
![image](https://user-images.githubusercontent.com/53182545/103659652-f3c88880-4f6c-11eb-8a4e-802e3da58db7.png)

