### PR TITLE
YLP-611 Hide "go to original article" option in ZD widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Blip is the web front end for YourLoops system.
 It is based on Tidepool Blip 1.27.
 
 ## Unreleased
+### Changed
+- YLP-611: Hide "go to original article" option in ZD widget
+
 ### Fixed
 - YLP-878 Wrong settings for glucose units uploaded by the handset
 - YLP-882 Wrong dates in the PDF report

--- a/templates/zendesk.js
+++ b/templates/zendesk.js
@@ -24,6 +24,9 @@ window.zESettings = {
           });
         }
       }
+    },
+    helpCenter: {
+      originalArticleButton: false
     }
   }
 };


### PR DESCRIPTION
Hide "go to original article" option in ZD widget

Before:
![image](https://user-images.githubusercontent.com/20857151/127993584-3340223c-7d34-41d9-b93e-f8fbbb300ef2.png)

After 
![image](https://user-images.githubusercontent.com/20857151/127993658-0311144f-4f4e-4f90-a345-9bfc60272bed.png)
