### PR TITLE
Fix missing locale file for deploy script in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ FROM base as content
 WORKDIR /content
 COPY ./dist/static ./static-dist/
 COPY ./templates ./templates
+COPY ./locales ./locales
 
 # this part contains the aws lambda middleware
 FROM base as lambda
@@ -61,5 +62,6 @@ COPY --from=deployment --chown=node:node /cloudfront-dist ./cloudfront-dist
 COPY --from=deployment --chown=node:node /cloudfront-dist/deploy.sh ./deploy.sh
 COPY --from=content --chown=node:node /content/static-dist ./static
 COPY --from=content --chown=node:node /content/templates ./templates
+COPY --from=content --chown=node:node /content/locales ./locales
 ENTRYPOINT [ "/bin/sh" ]
 CMD [ "deploy.sh" ]


### PR DESCRIPTION
Regression introduce in the PR https://github.com/mdblp/blip/pull/616
The deployment script is not run on PR, so we missed it.

See https://jenkins.ci.diabeloop.eu/job/mdblp/job/blip/job/dblp/205/