### PR TITLE
YLP-1029 verify locales

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 registry=https://nexus.ci.diabeloop.eu/repository/npm-diabeloop/
 email=jenkins@diabeloop.fr
-//nexus.ci.diabeloop.eu/repository/npm-diabeloop/:_auth=${NEXUS_TOKEN}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,22 @@ pipeline {
                 }
             }
         }
+        stage('Check for missing translations') {
+            when {
+                expression {
+                    env.GIT_BRANCH == "dblp"
+                }
+            }
+            agent {
+                dockerfile {
+                    filename 'Dockerfile.build'
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'npm run check-locales'
+            }
+        }
         stage('Publish') {
             when {
                 expression {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mrproper": "npm run clean && lerna run mrproper",
     "postmrproper": "rm -rf node_modules cloudfront-dist/deployment/node_modules server/node_modules",
     "clean": "lerna exec -- rm -rf dist coverage deploy reports && lerna clean --yes",
+    "check-locales": "node ./verifylocales.js",
     "postclean": "rm -rf doc dist coverage",
     "info": "lerna info",
     "prebuild": "rm -rf dist",

--- a/verifylocales.js
+++ b/verifylocales.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+const path = require('path');
+const localeDir = `${__dirname}/locales`;
+const localeRef = require("./locales/en/yourloops.json");
+let returnCode = 0;
+
+function checkLocaleFiles(lang) {
+  const content = require(path.resolve(localeDir, lang, "yourloops.json"));
+  let nbOfUnstranslatedStrings = 0;
+  for(key in localeRef) {
+    const val = content[key];
+    if( val === undefined) {
+      console.error(`${lang}: key ${key} is not translated!`);
+      nbOfUnstranslatedStrings++;
+    }
+    // if( val === key) {
+    //   console.warn(`value for ${key} is the same as the key`);
+    // }
+  }
+  if (nbOfUnstranslatedStrings > 0) {
+    returnCode = 1;
+    console.log(`Number of unstranlated strings for "${lang}": ${nbOfUnstranslatedStrings}`);
+  }
+
+}
+const localeFiles = fs.readdirSync(localeDir);
+
+localeFiles.forEach( (lang) => {
+  if (lang !== "languages.json") {
+    checkLocaleFiles(lang)
+  }
+});
+
+process.exit(returnCode);


### PR DESCRIPTION
Add a step in Jenkins to fail the build if locale files are not correct.
Criteria:
1. keys from the "EN" (the reference) are not found in other languages.
2. TO DO: keys found in code are not found in locales
3. TODO; keys present in locale files are not used in code