### PR TITLE
YLP-1129 Pending patient not displayed into HCP view when already in a team or private practice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ It is based on Tidepool Blip 1.27.
 - YLP-1101 Yourloops logo redirect not working for HCPs
 - YLP-1109 YourLoops main menu sometimes do not disappear as it should
 - YLP-1116 Missing password strength meter into reset password page
+- YLP-1129 Pending patient not displayed into HCP view when already in a team or private practice
 - YLP-1148 Average daily carbs is null in PDF report
 - YLP-1169 Fix German translation of Dietitian
 ### Engineering Use

--- a/packages/yourloops/lib/team/hook.tsx
+++ b/packages/yourloops/lib/team/hook.tsx
@@ -288,6 +288,11 @@ function TeamContextImpl(teamAPI: TeamAPI, directShareAPI: DirectShareAPI): Team
     return typeof tm === "undefined";
   };
 
+  const isUserInvitationPending = (user: TeamUser, teamId: string): boolean => {
+    const tm = user.members.find((tm) => tm.team.id === teamId && tm.status === UserInvitationStatus.pending);
+    return !!tm;
+  };
+
   const isInTeam = (user: TeamUser, teamId: string): boolean => {
     const tm = user.members.find((tm) => tm.team.id === teamId);
     return typeof tm === "object";
@@ -553,6 +558,7 @@ function TeamContextImpl(teamAPI: TeamAPI, directShareAPI: DirectShareAPI): Team
     isUserTheOnlyAdministrator,
     isInvitationPending,
     isOnlyPendingInvitation,
+    isUserInvitationPending,
     isInTeam,
     invitePatient,
     inviteMember,

--- a/packages/yourloops/lib/team/hook.tsx
+++ b/packages/yourloops/lib/team/hook.tsx
@@ -293,6 +293,11 @@ function TeamContextImpl(teamAPI: TeamAPI, directShareAPI: DirectShareAPI): Team
     return !!tm;
   };
 
+  const isInAtLeastATeam = (user: TeamUser): boolean => {
+    const tm = user.members.find((tm) => tm.status === UserInvitationStatus.accepted);
+    return !!tm;
+  };
+
   const isInTeam = (user: TeamUser, teamId: string): boolean => {
     const tm = user.members.find((tm) => tm.team.id === teamId);
     return typeof tm === "object";
@@ -559,6 +564,7 @@ function TeamContextImpl(teamAPI: TeamAPI, directShareAPI: DirectShareAPI): Team
     isInvitationPending,
     isOnlyPendingInvitation,
     isUserInvitationPending,
+    isInAtLeastATeam,
     isInTeam,
     invitePatient,
     inviteMember,

--- a/packages/yourloops/lib/team/models.ts
+++ b/packages/yourloops/lib/team/models.ts
@@ -151,6 +151,12 @@ export interface TeamContext {
    */
   isOnlyPendingInvitation: (user: TeamUser) => boolean;
   /**
+   * @param user The user to test
+   * @param teamId A team id
+   * @returns {boolean} True if members status is pending in given team
+   */
+   isUserInvitationPending: (user: TeamUser, teamId: string) => boolean;
+  /**
    * Return true if this user is in a specific team
    * @param user The user to test
    * @param teamId A team id

--- a/packages/yourloops/lib/team/models.ts
+++ b/packages/yourloops/lib/team/models.ts
@@ -157,6 +157,11 @@ export interface TeamContext {
    */
    isUserInvitationPending: (user: TeamUser, teamId: string) => boolean;
   /**
+   * @param user The user to test
+   * @returns {boolean} True if members status is accepted in at least a team
+   */
+   isInAtLeastATeam: (user: TeamUser) => boolean;
+  /**
    * Return true if this user is in a specific team
    * @param user The user to test
    * @param teamId A team id

--- a/packages/yourloops/pages/hcp/patients/models.ts
+++ b/packages/yourloops/pages/hcp/patients/models.ts
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { SortDirection, SortFields } from "../../../models/generic";
+import { FilterType, SortDirection, SortFields } from "../../../models/generic";
 import { TeamUser } from "../../../lib/team";
 
 export interface PatientListProps {
@@ -34,6 +34,7 @@ export interface PatientListProps {
   flagged: string[];
   order: SortDirection;
   orderBy: SortFields;
+  filter?: FilterType | string;
   onClickPatient: (user: TeamUser) => void;
   onFlagPatient: (userId: string) => Promise<void>;
   onSortList: (field: SortFields, direction: SortDirection) => void;
@@ -44,6 +45,7 @@ export interface PatientElementProps {
   trNA: string;
   patient: TeamUser;
   flagged: string[];
+  filter?: FilterType | string;
   onClickPatient: (user: TeamUser) => void;
   onFlagPatient: (userId: string) => Promise<void>;
   onClickRemovePatient: (patient: TeamUser) => void;

--- a/packages/yourloops/pages/hcp/patients/page.tsx
+++ b/packages/yourloops/pages/hcp/patients/page.tsx
@@ -112,7 +112,7 @@ function doCompare(a: TeamUser, b: TeamUser, orderBy: SortFields): number {
   return aValue - bValue;
 }
 
-function updatePatientList(
+export function updatePatientList(
   teamHook: TeamContext,
   flagged: string[],
   filter: string,
@@ -122,13 +122,14 @@ function updatePatientList(
   sortFlaggedFirst: boolean
 ): TeamUser[] {
   const allPatients = teamHook.getPatients();
-
   let patients: Readonly<TeamUser>[];
-  if (filterType !== FilterType.pending) {
-    // Do not display pending invitation if not requested
-    patients = allPatients.filter((patient) => !teamHook.isOnlyPendingInvitation(patient));
+  if (!(filterType in FilterType)) {
+    //filterType is a team id, retrieve all patients not pending in given team
+    patients = allPatients.filter((patient) => !teamHook.isUserInvitationPending(patient, filterType));
+  } else if (filterType === FilterType.pending) {
+    patients = allPatients.filter((patient) => teamHook.isInvitationPending(patient));
   } else {
-    patients = allPatients.filter((patient) => teamHook.isOnlyPendingInvitation(patient));
+    patients = allPatients.filter((patient) => !teamHook.isOnlyPendingInvitation(patient));
   }
 
   const searchByName = filter.length > 0;

--- a/packages/yourloops/pages/hcp/patients/page.tsx
+++ b/packages/yourloops/pages/hcp/patients/page.tsx
@@ -382,6 +382,7 @@ function PatientListPage(): JSX.Element {
           flagged={flagged}
           order={order}
           orderBy={orderBy}
+          filter={filterType}
           onClickPatient={handleSelectPatient}
           onFlagPatient={handleFlagPatient}
           onSortList={handleSortList}

--- a/packages/yourloops/pages/hcp/patients/table.tsx
+++ b/packages/yourloops/pages/hcp/patients/table.tsx
@@ -48,7 +48,7 @@ import FlagOutlineIcon from "@material-ui/icons/FlagOutlined";
 import IconActionButton from "../../../components/buttons/icon-action";
 import PersonRemoveIcon from "../../../components/icons/PersonRemoveIcon";
 
-import { SortDirection, SortFields } from "../../../models/generic";
+import { FilterType, SortDirection, SortFields } from "../../../models/generic";
 import { MedicalData } from "../../../models/device-data";
 import metrics from "../../../lib/metrics";
 import { getUserFirstName, getUserLastName } from "../../../lib/utils";
@@ -86,7 +86,7 @@ const patientListStyle = makeStyles(
 );
 
 function PatientRow(props: PatientElementProps): JSX.Element {
-  const { trNA, patient, flagged, onClickPatient, onFlagPatient, onClickRemovePatient } = props;
+  const { trNA, patient, flagged, filter, onClickPatient, onFlagPatient, onClickRemovePatient } = props;
   const { t } = useTranslation("yourloops");
   const authHook = useAuth();
   const teamHook = useTeam();
@@ -123,6 +123,8 @@ function PatientRow(props: PatientElementProps): JSX.Element {
   const rowId = `patients-list-row-${userId.replace(/@/g, "_")}`;
   const session = authHook.session();
   const isPendingInvitation = teamHook.isOnlyPendingInvitation(patient);
+  const hasPendingInvitation = teamHook.isInvitationPending(patient);
+  const isAlreadyInATeam = teamHook.isInAtLeastATeam(patient);
 
   React.useEffect(() => {
     const observedElement = rowRef.current;
@@ -161,7 +163,7 @@ function PatientRow(props: PatientElementProps): JSX.Element {
     return _.noop;
   }, [medicalData, patient, session, isPendingInvitation, teamHook, rowRef]);
 
-  const firstRowIcon = isPendingInvitation ?
+  const firstRowIcon = filter === FilterType.pending && hasPendingInvitation ?
     (<Tooltip
       id={`${rowId}-tooltip-pending`}
       title={t("pending-invitation") as string}
@@ -182,7 +184,7 @@ function PatientRow(props: PatientElementProps): JSX.Element {
       id={rowId}
       tabIndex={-1}
       hover
-      onClick={isPendingInvitation ? undefined : onRowClick}
+      onClick={hasPendingInvitation && !isAlreadyInATeam ? undefined : onRowClick}
       className={`${classes.tableRow} patients-list-row`}
       data-userid={userId}
       data-email={email}
@@ -206,7 +208,7 @@ function PatientRow(props: PatientElementProps): JSX.Element {
 }
 
 function PatientListTable(props: PatientListProps): JSX.Element {
-  const { patients, flagged, order, orderBy, onClickPatient, onFlagPatient, onSortList, onClickRemovePatient } = props;
+  const { patients, flagged, order, filter, orderBy, onClickPatient, onFlagPatient, onSortList, onClickRemovePatient } = props;
   const { t } = useTranslation("yourloops");
   const classes = patientListStyle();
   const trNA = t("N/A");
@@ -218,6 +220,7 @@ function PatientListTable(props: PatientListProps): JSX.Element {
         trNA={trNA}
         patient={patient}
         flagged={flagged}
+        filter={filter}
         onClickPatient={onClickPatient}
         onFlagPatient={onFlagPatient}
         onClickRemovePatient={onClickRemovePatient}

--- a/packages/yourloops/test/lib/team/hook.test.tsx
+++ b/packages/yourloops/test/lib/team/hook.test.tsx
@@ -26,14 +26,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { expect } from "chai";
+import React from "react";
+import { render, unmountComponentAtNode } from "react-dom";
+import { act } from "react-dom/test-utils";
 import * as sinon from "sinon";
-import { TeamAPI } from "../../../lib/team";
+import { AuthContextProvider } from "../../../lib/auth";
+import { Team, TeamAPI, TeamContext, TeamContextProvider, TeamMember, TeamUser, useTeam } from "../../../lib/team";
+import { UserInvitationStatus } from "../../../models/generic";
 import {
-  teams,
-  members,
-  patients,
-  emptyTeam3,
+  emptyTeam3, members,
+  patients, teams
 } from "../../common";
+import { authHookHcp } from "../auth/hook.test";
+import { directShareAPI } from "../direct-share/hook.test";
 
 export const teamAPI: TeamAPI = {
   fetchTeams: sinon.stub().resolves(teams),
@@ -67,3 +73,73 @@ export function resetTeamAPIStubs(): void {
   (teamAPI.fetchTeams as sinon.SinonStub).resolves(teams);
   (teamAPI.fetchPatients as sinon.SinonStub).resolves(patients);
 }
+
+export function testTeamHook(): void {
+  let container: HTMLElement | null = null;
+
+  let teamHook: TeamContext;
+
+  async function mountComponent(): Promise<void> {
+    const DummyComponent = (): JSX.Element => {
+      teamHook = useTeam();
+      return (<div />);
+    };
+    await act(() => {
+      return new Promise(resolve => render(
+        <AuthContextProvider value={authHookHcp}>
+          <TeamContextProvider teamAPI={teamAPI} directShareAPI={directShareAPI}>
+            <DummyComponent />
+          </TeamContextProvider>
+        </AuthContextProvider>,
+        container, resolve)
+      );
+    });
+  }
+
+  beforeEach(async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    await mountComponent();
+  });
+
+  afterEach(() => {
+    if (container) {
+      unmountComponentAtNode(container);
+      container.remove();
+      container = null;
+    }
+  });
+
+  describe("isUserInvitationPending", () => {
+    it("should return true when team user has a pending status in given team", () => {
+      const teamId = "fakeTeamId";
+      const teamUser: TeamUser = {
+        members: [
+          {
+            team: { id: teamId } as Team,
+            status: UserInvitationStatus.pending,
+          } as TeamMember,
+        ],
+      } as TeamUser;
+
+      const res = teamHook.isUserInvitationPending(teamUser, teamId);
+      expect(res).to.be.true;
+    });
+
+    it("should return false when team user does not have a pending status in given team", () => {
+      const teamId = "fakeTeamId";
+      const teamUser: TeamUser = {
+        members: [
+          {
+            team: { id: teamId } as Team,
+            status: UserInvitationStatus.accepted,
+          } as TeamMember,
+        ],
+      } as TeamUser;
+
+      const res = teamHook.isUserInvitationPending(teamUser, teamId);
+      expect(res).to.be.false;
+    });
+  });
+}
+

--- a/packages/yourloops/test/lib/team/hook.test.tsx
+++ b/packages/yourloops/test/lib/team/hook.test.tsx
@@ -140,6 +140,44 @@ export function testTeamHook(): void {
       const res = teamHook.isUserInvitationPending(teamUser, teamId);
       expect(res).to.be.false;
     });
+
+    describe("isInAtLeastATeam", () => {
+      it("should return false when team user does not have an accepted status in any team", () => {
+        const teamUser: TeamUser = {
+          members: [
+            {
+              team: { id: "teamId1" } as Team,
+              status: UserInvitationStatus.pending,
+            } as TeamMember,
+            {
+              team: { id: "teamId2" } as Team,
+              status: UserInvitationStatus.pending,
+            } as TeamMember,
+          ],
+        } as TeamUser;
+
+        const res = teamHook.isInAtLeastATeam(teamUser);
+        expect(res).to.be.false;
+      });
+
+      it("should return true when team user does has an accepted status in a team", () => {
+        const teamUser: TeamUser = {
+          members: [
+            {
+              team: { id: "teamId1" } as Team,
+              status: UserInvitationStatus.pending,
+            } as TeamMember,
+            {
+              team: { id: "teamId2" } as Team,
+              status: UserInvitationStatus.accepted,
+            } as TeamMember,
+          ],
+        } as TeamUser;
+
+        const res = teamHook.isInAtLeastATeam(teamUser);
+        expect(res).to.be.true;
+      });
+    });
   });
 }
 

--- a/packages/yourloops/test/lib/team/index.ts
+++ b/packages/yourloops/test/lib/team/index.ts
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2021, Diabeloop
- * Lib tests
+ * Copyright (c) 2022, Diabeloop
+ * Auth tests
  *
  * All rights reserved.
  *
@@ -26,26 +26,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import testsSoup from "./soup";
-import testCookiesManager from "./cookies-manager.test";
-import testLanguage from "./language.test";
-import testMetrics from "./metrics.test";
-import testZendesk from "./zendesk.test";
-import testAuth from "./auth";
-import testNotifications from "./notifications";
-import testRegex from "./regex.test";
-import testTeam from "./team";
+import { testTeamHook } from "./hook.test";
 
-function testLib(): void {
-  describe("SOUP", testsSoup);
-  describe("CookiesManager", testCookiesManager);
-  describe("Language", testLanguage);
-  describe("Metrics", testMetrics);
-  describe("Zendesk", testZendesk);
-  describe("Auth", testAuth);
-  describe("Team", testTeam);
-  describe("Notifications", testNotifications);
-  describe("Regex", testRegex);
+
+function testTeam(): void {
+  describe("Hook", testTeamHook);
 }
 
-export default testLib;
+export default testTeam;

--- a/packages/yourloops/test/pages/hcp/index.ts
+++ b/packages/yourloops/test/pages/hcp/index.ts
@@ -27,6 +27,7 @@
  */
 
 import testPatientsSecondaryBar from "./patients-secondary-bar.test";
+import testPatientListPage from "./patients-list-page.test";
 import testPatientListTable from "./patients-list-table.test";
 import testPatientRemoveDialog from "./patient-remove-dialog.test";
 import testTeamCard from "./team-card.test";
@@ -42,6 +43,7 @@ function testHCPPage(): void {
   describe("Patient List", () => {
     describe("AppBar", testPatientsSecondaryBar);
     describe("Table", testPatientListTable);
+    describe("Page", testPatientListPage);
     describe("Remove-dialog", testPatientRemoveDialog);
   });
   describe("Teams", () => {

--- a/packages/yourloops/test/pages/hcp/patients-list-page.test.tsx
+++ b/packages/yourloops/test/pages/hcp/patients-list-page.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2022, Diabeloop
+ * HCP patient list bar tests
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { expect } from "chai";
+import React from "react";
+import { render, unmountComponentAtNode } from "react-dom";
+import { act } from "react-dom/test-utils";
+import { AuthContextProvider } from "../../../lib/auth";
+import { NotificationContextProvider } from "../../../lib/notifications";
+import { TeamContext, TeamContextProvider, TeamUser, useTeam } from "../../../lib/team";
+import { FilterType, SortDirection, SortFields, UserInvitationStatus } from "../../../models/generic";
+import PatientListPage, { updatePatientList } from "../../../pages/hcp/patients/page";
+import { authHookHcp } from "../../lib/auth/hook.test";
+import { stubNotificationContextValue } from "../../lib/notifications/hook.test";
+import { teamAPI } from "../../lib/team/hook.test";
+
+
+function testPatientListPage(): void {
+  let team: TeamContext;
+  let patients: TeamUser[];
+
+  let container: HTMLElement | null = null;
+
+  const PatientListPageComponent = (): JSX.Element => {
+    team = useTeam();
+    patients = team.getPatients();
+
+    return (
+      <PatientListPage />
+    );
+  };
+
+  async function mountComponent(): Promise<void> {
+    await act(() => {
+      return new Promise((resolve) => {
+        render(
+          <AuthContextProvider value={authHookHcp}>
+            <NotificationContextProvider value={stubNotificationContextValue}>
+              <TeamContextProvider teamAPI={teamAPI}>
+                <PatientListPageComponent />
+              </TeamContextProvider>
+            </NotificationContextProvider>
+          </AuthContextProvider>, container, resolve);
+      });
+    });
+  }
+
+  before(async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    await mountComponent();
+  });
+
+  after(() => {
+    if (container) {
+      unmountComponentAtNode(container);
+      container.remove();
+      container = null;
+    }
+  });
+
+  it("updatePatientList should return correct patients when filter is pending", () => {
+    //given
+    const patientExpected = patients.filter(patient => patient.members.find(member => member.status === UserInvitationStatus.pending) !== undefined);
+
+    //when
+    const patientReceived = updatePatientList(team, [], "", FilterType.pending, SortFields.lastname, SortDirection.asc, false);
+
+    //then
+    expect(patientReceived).to.eql(patientExpected);
+  });
+
+  it("updatePatientList should return correct patients when filter is team id", () => {
+    //given
+    const teamId = patients[0].members[0].team.id;
+    const patientExpected = patients.filter(patient => patient.members.find(member => member.team.id === teamId && member.status !== UserInvitationStatus.pending) !== undefined);
+
+    //when
+    const patientReceived = updatePatientList(team, [], "", teamId, SortFields.lastname, SortDirection.asc, false);
+
+    //then
+    expect(patientReceived).to.eql(patientExpected);
+  });
+}
+
+export default testPatientListPage;


### PR DESCRIPTION
- When filter is set on "Pending", display any patient having an invitation with a "pending" status
- When filter is set on a team name, display any patient having an invitation in the team with a non "pending" status
- Added tests