### PR TITLE
YLP-1842 Disable sourcemap for production builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ It is based on Tidepool Blip 1.27.
 - YLP-1658 Creating a note does not create it at the time selected
 - YLP-1659 Language is not updated with user preferences
 - YLP-1694 Disable save button in medical record dialog for a patient
+- YLP-1842 Disable sourcemap for production builds
 
 ## 3.0.0 - 2022-06-16
 ### Added

--- a/packages/yourloops/webpack.config.js
+++ b/packages/yourloops/webpack.config.js
@@ -106,6 +106,8 @@ plugins.push(
   new CopyWebpackPlugin({ patterns: [...patterns, { from: '../../branding/palette.css', to: 'palette.css' }] })
 )
 
+console.log(`isTest ${isTest}, isProduction ${isProduction}, isDev ${isDev}`)
+
 /** @type {webpack.Configuration & { devServer: { [index: string]: any; }}} */
 const webpackConfig = {
   entry: {
@@ -131,8 +133,9 @@ const webpackConfig = {
   mode,
   stats: 'minimal', // See https://webpack.js.org/configuration/stats/
 
-  // Enable sourcemaps for debugging webpack output.
-  devtool: isTest || isDev ? 'inline-source-map' : 'source-map',
+  // Enable sourcemaps for debugging webpack's output.
+  devtool: isTest || isDev ? 'inline-source-map' : false,
+  // todo: enhance this part
   devServer: {
     allowedHosts: 'auto',
     compress: false,

--- a/packages/yourloops/webpack.config.js
+++ b/packages/yourloops/webpack.config.js
@@ -23,7 +23,7 @@ const isTest = process.env.NODE_ENV === 'test'
 const isProduction = mode === 'production'
 const isDev = !isProduction
 
-console.log(`Compiling ${pkg.name} v${pkg.version} for ${mode}`)
+console.log(`Compiling ${pkg.name} v${pkg.version} for ${mode}/${process.env.NODE_ENV}.`)
 
 if (process.env.USE_WEBPACK_DEV_SERVER === 'true') {
   console.log(buildConfig)
@@ -105,8 +105,6 @@ for (const branding of brandings) {
 plugins.push(
   new CopyWebpackPlugin({ patterns: [...patterns, { from: '../../branding/palette.css', to: 'palette.css' }] })
 )
-
-console.log(`isTest ${isTest}, isProduction ${isProduction}, isDev ${isDev}`)
 
 /** @type {webpack.Configuration & { devServer: { [index: string]: any; }}} */
 const webpackConfig = {


### PR DESCRIPTION
This is a simple and radical change to remove access to source code from production environments.
Rather than "false" which totally disable the devtools in production we could use 'hidden-source-map' or 'nosources-source-map'.
Another idea: keep sourcemap but protect access to map files (how? rule on cloudfront to filter based on ips?) or remove source map (using a simple rm dist/*.map) at the end of the build process only for production images...
See https://webpack.js.org/configuration/devtool/ 
Open to discussion, but as is it solves the security problem :ok_hand: :