### PR TITLE
Improving CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,7 @@ jobs:
           images: ${{ secrets.REGISTRY }}/blip
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,enable=true,prefix=${{ steps.package-version.outputs.semver }}-beta-,event=pr
 
       - name: Build and push blip Docker image
         uses: docker/build-push-action@v3
@@ -309,12 +310,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # for now disable as we not used the changelog (missing UNRELEASED info)
-  #      - name: Creating new github tag
-  #        uses: rickstaa/action-create-tag@v1
-  #        with:
-  #          tag: ${{ steps.meta.outputs.version }}
-  #          force_push_tag: true
+      - name: Creating new github tag
+        if: github.ref_name != 'dblp'
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: v${{ steps.meta.outputs.version }}
+          force_push_tag: true
 
   documentation:
     if: github.ref_name == 'dblp'

--- a/.github/workflows/publish_on_request.yml
+++ b/.github/workflows/publish_on_request.yml
@@ -88,12 +88,12 @@ jobs:
       - name: Build and push blip Docker image
         uses: docker/build-push-action@v3
         env:
-          PR_NUMBER: ${{github.event.issue.number}}
+          PR_NUMBER: ${{ github.event.issue.number }}
         with:
           context: .
           push: true
           platforms: linux/arm64,linux/amd64
-          tags:  ${{ secrets.REGISTRY }}/blip:${{ steps.package-version.outputs.semver }}-PR-${{env.PR_NUMBER}}
+          tags:  ${{ secrets.REGISTRY }}/blip:${{ steps.package-version.outputs.semver }}-beta-${{ env.PR_NUMBER }}
 
       - name: Creating new github tag
         uses: rickstaa/action-create-tag@v1


### PR DESCRIPTION
As we discussed together, a good practice is to name our docker images and github tags in lowercase. Improving CI in this way.

For the moment, it still needs to comment the condition `if: github.ref_name == 'dblp'` in `build` and `publish` jobs to push a PR image.

Will be improved soon ;)