### PR TITLE
fix publish comment trigger: wrong commit id

### DIFF
--- a/.github/workflows/publish_on_request.yml
+++ b/.github/workflows/publish_on_request.yml
@@ -114,4 +114,5 @@ jobs:
         uses: rickstaa/action-create-tag@v1
         with:
           tag: v${{ steps.changelog-version.outputs.semver }}-${{ env.PR_NUMBER }}
+          commit_sha: ${{ steps.comment-branch.outputs.head_sha }}
           force_push_tag: true


### PR DESCRIPTION
- fix tag
- fix: take wrong commit sha by default on a Pr with tag actions

## Checklist
- [ ] PR name contains the Jira ticket number
- [ ] Changelog updated
- [ ] Code tested (unit tests and integration tests)
- [ ] No console errors/warnings in integration tests
- [ ] No translation files updated (except for English files)
- [ ] Code formatted on every file
- [ ] Copyright added on every file
- [ ] End-to-end tests successful on CI
